### PR TITLE
Temporary Access Restrictions

### DIFF
--- a/dev/alive/docker-compose.yaml
+++ b/dev/alive/docker-compose.yaml
@@ -24,6 +24,9 @@ services:
       - traefik.http.routers.alive-coreapi-${COMPOSE_PROJECT_NAME}.tls=true
       - traefik.http.routers.alive-coreapi-${COMPOSE_PROJECT_NAME}.tls.certresolver=letsencrypt
 
+      # TODO remove after auth implemented via oauth2-proxy
+      # only allow access from localhost and CIRG IP ranges
+      - traefik.http.routers.alive-coreapi-${COMPOSE_PROJECT_NAME}.middlewares=limit-access-to-cirg-dc-cidr
   node:
     labels:
       - traefik.enable=true
@@ -32,5 +35,8 @@ services:
       - traefik.http.routers.alive-node-${COMPOSE_PROJECT_NAME}.tls=true
       - traefik.http.routers.alive-node-${COMPOSE_PROJECT_NAME}.tls.certresolver=letsencrypt
 
+      # TODO remove after auth implemented via oauth2-proxy
+      # only allow access from localhost and CIRG IP ranges
+      - traefik.http.routers.alive-node-${COMPOSE_PROJECT_NAME}.middlewares=limit-access-to-cirg-dc-cidr
 volumes:
   leaf-alive-mssql:

--- a/dev/gateway/docker-compose.yaml
+++ b/dev/gateway/docker-compose.yaml
@@ -24,6 +24,9 @@ services:
       - traefik.http.routers.gateway-coreapi-${COMPOSE_PROJECT_NAME}.tls=true
       - traefik.http.routers.gateway-coreapi-${COMPOSE_PROJECT_NAME}.tls.certresolver=letsencrypt
 
+      # TODO remove after auth implemented via oauth2-proxy
+      # only allow access from localhost and CIRG IP ranges
+      - traefik.http.routers.gateway-coreapi-${COMPOSE_PROJECT_NAME}.middlewares=limit-access-to-cirg-dc-cidr
   node:
     extends:
       file: ../common-services.yaml
@@ -35,6 +38,9 @@ services:
       - traefik.http.routers.gateway-node-${COMPOSE_PROJECT_NAME}.tls=true
       - traefik.http.routers.gateway-node-${COMPOSE_PROJECT_NAME}.tls.certresolver=letsencrypt
 
+      # TODO remove after auth implemented via oauth2-proxy
+      # only allow access from localhost and CIRG IP ranges
+      - traefik.http.routers.gateway-node-${COMPOSE_PROJECT_NAME}.middlewares=limit-access-to-cirg-dc-cidr
   clin-db:
     extends:
       file: ../common-services.yaml

--- a/dev/hymtruth/docker-compose.yaml
+++ b/dev/hymtruth/docker-compose.yaml
@@ -24,6 +24,9 @@ services:
       - traefik.http.routers.hymtruth-coreapi-${COMPOSE_PROJECT_NAME}.tls=true
       - traefik.http.routers.hymtruth-coreapi-${COMPOSE_PROJECT_NAME}.tls.certresolver=letsencrypt
 
+      # TODO remove after auth implemented via oauth2-proxy
+      # only allow access from localhost and CIRG IP ranges
+      - traefik.http.routers.hymtruth-coreapi-${COMPOSE_PROJECT_NAME}.middlewares=limit-access-to-cirg-dc-cidr
   node:
     labels:
       - traefik.enable=true
@@ -32,5 +35,8 @@ services:
       - traefik.http.routers.hymtruth-node-${COMPOSE_PROJECT_NAME}.tls=true
       - traefik.http.routers.hymtruth-node-${COMPOSE_PROJECT_NAME}.tls.certresolver=letsencrypt
 
+      # TODO remove after auth implemented via oauth2-proxy
+      # only allow access from localhost and CIRG IP ranges
+      - traefik.http.routers.hymtruth-node-${COMPOSE_PROJECT_NAME}.middlewares=limit-access-to-cirg-dc-cidr
 volumes:
   leaf-hymtruth-mssql:

--- a/dev/mash/docker-compose.yaml
+++ b/dev/mash/docker-compose.yaml
@@ -24,6 +24,9 @@ services:
       - traefik.http.routers.mash-coreapi-${COMPOSE_PROJECT_NAME}.tls=true
       - traefik.http.routers.mash-coreapi-${COMPOSE_PROJECT_NAME}.tls.certresolver=letsencrypt
 
+      # TODO remove after auth implemented via oauth2-proxy
+      # only allow access from localhost and CIRG IP ranges
+      - traefik.http.routers.mash-coreapi-${COMPOSE_PROJECT_NAME}.middlewares=limit-access-to-cirg-dc-cidr
   node:
     labels:
       - traefik.enable=true
@@ -32,5 +35,8 @@ services:
       - traefik.http.routers.mash-node-${COMPOSE_PROJECT_NAME}.tls=true
       - traefik.http.routers.mash-node-${COMPOSE_PROJECT_NAME}.tls.certresolver=letsencrypt
 
+      # TODO remove after auth implemented via oauth2-proxy
+      # only allow access from localhost and CIRG IP ranges
+      - traefik.http.routers.mash-node-${COMPOSE_PROJECT_NAME}.middlewares=limit-access-to-cirg-dc-cidr
 volumes:
   leaf-mash-mssql:

--- a/dev/mstudy/docker-compose.yaml
+++ b/dev/mstudy/docker-compose.yaml
@@ -24,6 +24,9 @@ services:
       - traefik.http.routers.mstudy-coreapi-${COMPOSE_PROJECT_NAME}.tls=true
       - traefik.http.routers.mstudy-coreapi-${COMPOSE_PROJECT_NAME}.tls.certresolver=letsencrypt
 
+      # TODO remove after auth implemented via oauth2-proxy
+      # only allow access from localhost and CIRG IP ranges
+      - traefik.http.routers.mstudy-coreapi-${COMPOSE_PROJECT_NAME}.middlewares=limit-access-to-cirg-dc-cidr
   node:
     labels:
       - traefik.enable=true
@@ -32,5 +35,8 @@ services:
       - traefik.http.routers.mstudy-node-${COMPOSE_PROJECT_NAME}.tls=true
       - traefik.http.routers.mstudy-node-${COMPOSE_PROJECT_NAME}.tls.certresolver=letsencrypt
 
+      # TODO remove after auth implemented via oauth2-proxy
+      # only allow access from localhost and CIRG IP ranges
+      - traefik.http.routers.mstudy-node-${COMPOSE_PROJECT_NAME}.middlewares=limit-access-to-cirg-dc-cidr
 volumes:
   leaf-mstudy-mssql:

--- a/dev/radar/docker-compose.yaml
+++ b/dev/radar/docker-compose.yaml
@@ -24,6 +24,9 @@ services:
       - traefik.http.routers.radar-coreapi-${COMPOSE_PROJECT_NAME}.tls=true
       - traefik.http.routers.radar-coreapi-${COMPOSE_PROJECT_NAME}.tls.certresolver=letsencrypt
 
+      # TODO remove after auth implemented via oauth2-proxy
+      # only allow access from localhost and CIRG IP ranges
+      - traefik.http.routers.radar-coreapi-${COMPOSE_PROJECT_NAME}.middlewares=limit-access-to-cirg-dc-cidr
   node:
     labels:
       - traefik.enable=true
@@ -31,6 +34,10 @@ services:
       - traefik.http.routers.radar-node-${COMPOSE_PROJECT_NAME}.entrypoints=websecure
       - traefik.http.routers.radar-node-${COMPOSE_PROJECT_NAME}.tls=true
       - traefik.http.routers.radar-node-${COMPOSE_PROJECT_NAME}.tls.certresolver=letsencrypt
+
+      # TODO remove after auth implemented via oauth2-proxy
+      # only allow access from localhost and CIRG IP ranges
+      - traefik.http.routers.radar-node-${COMPOSE_PROJECT_NAME}.middlewares=limit-access-to-cirg-dc-cidr
 
 volumes:
   leaf-radar-mssql:


### PR DESCRIPTION
Temporarily, only allow access to Leaf containers from localhost

Once robust auth is added, these rules will not be necessary and can be removed