### PR TITLE
Apply UI customizations via appsettings.json

### DIFF
--- a/dev/alive/appsettings.json
+++ b/dev/alive/appsettings.json
@@ -128,7 +128,7 @@
       "Enabled": false
     },
     "Help": {
-      "Enabled": true,
+      "Enabled": false,
       "Email": "cirg-adm+leaf@uw.edu",
       "URI": "https://www.example.edu/leaf-faq"
     }

--- a/dev/alive/appsettings.json
+++ b/dev/alive/appsettings.json
@@ -107,7 +107,7 @@
         "UpperBound": 10
       },
       "LowCellSizeMasking": {
-        "Enabled": false,
+        "Enabled": true,
         "Threshold": 10
       }
     }

--- a/dev/alive/appsettings.json
+++ b/dev/alive/appsettings.json
@@ -125,7 +125,7 @@
       "Enabled":  true
     },
     "PatientList": {
-      "Enabled": true
+      "Enabled": false
     },
     "Help": {
       "Enabled": true,

--- a/dev/gateway/appsettings.json
+++ b/dev/gateway/appsettings.json
@@ -128,7 +128,7 @@
       "Enabled": false
     },
     "Help": {
-      "Enabled": true,
+      "Enabled": false,
       "Email": "cirg-adm+leaf@uw.edu",
       "URI": "https://www.example.edu/leaf-faq"
     }

--- a/dev/gateway/appsettings.json
+++ b/dev/gateway/appsettings.json
@@ -107,7 +107,7 @@
         "UpperBound": 10
       },
       "LowCellSizeMasking": {
-        "Enabled": false,
+        "Enabled": true,
         "Threshold": 10
       }
     }

--- a/dev/gateway/appsettings.json
+++ b/dev/gateway/appsettings.json
@@ -125,7 +125,7 @@
       "Enabled":  true
     },
     "PatientList": {
-      "Enabled": true
+      "Enabled": false
     },
     "Help": {
       "Enabled": true,

--- a/dev/hymtruth/appsettings.json
+++ b/dev/hymtruth/appsettings.json
@@ -128,7 +128,7 @@
       "Enabled": false
     },
     "Help": {
-      "Enabled": true,
+      "Enabled": false,
       "Email": "cirg-adm+leaf@uw.edu",
       "URI": "https://www.example.edu/leaf-faq"
     }

--- a/dev/hymtruth/appsettings.json
+++ b/dev/hymtruth/appsettings.json
@@ -107,7 +107,7 @@
         "UpperBound": 10
       },
       "LowCellSizeMasking": {
-        "Enabled": false,
+        "Enabled": true,
         "Threshold": 10
       }
     }

--- a/dev/hymtruth/appsettings.json
+++ b/dev/hymtruth/appsettings.json
@@ -125,7 +125,7 @@
       "Enabled":  true
     },
     "PatientList": {
-      "Enabled": true
+      "Enabled": false
     },
     "Help": {
       "Enabled": true,

--- a/dev/mash/appsettings.json
+++ b/dev/mash/appsettings.json
@@ -128,7 +128,7 @@
       "Enabled": false
     },
     "Help": {
-      "Enabled": true,
+      "Enabled": false,
       "Email": "cirg-adm+leaf@uw.edu",
       "URI": "https://www.example.edu/leaf-faq"
     }

--- a/dev/mash/appsettings.json
+++ b/dev/mash/appsettings.json
@@ -107,7 +107,7 @@
         "UpperBound": 10
       },
       "LowCellSizeMasking": {
-        "Enabled": false,
+        "Enabled": true,
         "Threshold": 10
       }
     }

--- a/dev/mash/appsettings.json
+++ b/dev/mash/appsettings.json
@@ -125,7 +125,7 @@
       "Enabled":  true
     },
     "PatientList": {
-      "Enabled": true
+      "Enabled": false
     },
     "Help": {
       "Enabled": true,

--- a/dev/mstudy/appsettings.json
+++ b/dev/mstudy/appsettings.json
@@ -128,7 +128,7 @@
       "Enabled": false
     },
     "Help": {
-      "Enabled": true,
+      "Enabled": false,
       "Email": "cirg-adm+leaf@uw.edu",
       "URI": "https://www.example.edu/leaf-faq"
     }

--- a/dev/mstudy/appsettings.json
+++ b/dev/mstudy/appsettings.json
@@ -107,7 +107,7 @@
         "UpperBound": 10
       },
       "LowCellSizeMasking": {
-        "Enabled": false,
+        "Enabled": true,
         "Threshold": 10
       }
     }

--- a/dev/mstudy/appsettings.json
+++ b/dev/mstudy/appsettings.json
@@ -125,7 +125,7 @@
       "Enabled":  true
     },
     "PatientList": {
-      "Enabled": true
+      "Enabled": false
     },
     "Help": {
       "Enabled": true,

--- a/dev/radar/appsettings.json
+++ b/dev/radar/appsettings.json
@@ -128,7 +128,7 @@
       "Enabled": false
     },
     "Help": {
-      "Enabled": true,
+      "Enabled": false,
       "Email": "cirg-adm+leaf@uw.edu",
       "URI": "https://www.example.edu/leaf-faq"
     }

--- a/dev/radar/appsettings.json
+++ b/dev/radar/appsettings.json
@@ -107,7 +107,7 @@
         "UpperBound": 10
       },
       "LowCellSizeMasking": {
-        "Enabled": false,
+        "Enabled": true,
         "Threshold": 10
       }
     }

--- a/dev/radar/appsettings.json
+++ b/dev/radar/appsettings.json
@@ -125,7 +125,7 @@
       "Enabled":  true
     },
     "PatientList": {
-      "Enabled": true
+      "Enabled": false
     },
     "Help": {
       "Enabled": true,


### PR DESCRIPTION
This PR disables the following across all Leaf instances:
- patient list option in sidebar
- displaying actual totals when query results in fewer than 10 participants (see [here](https://leafdocs.rit.uw.edu/installation/installation_steps/6_appsettings/#deidentification))
- the help feature (currently we have no mechanism in place to process help requests sent to a secondary address, this may change eventually, but for now it is disabled)