### PR TITLE
Add trust troubleshooting tips to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,13 @@ To load a site-specific dataset into its corresponding database, invoke mysql as
 
     sql_file_path=/srv/www/leaf-scripts/cnics_data.phosphorus.2024.03.14.19.07.reduced.sql
     docker compose exec -T clin-db bash -c 'mysql --user=${MYSQL_USER} --password=${MYSQL_PASSWORD} ${SITE}' < $sql_file_path
+
+## Troubleshooting Federated Instances
+If trusted instances do not appear to be available for queries, and investigating the GET requests sent out by the gateway instance suggests calls to `/api/network/identity` on other instances are failing with a 401 error, then the following steps may be required to re-establish a working trust between instances.
+
+1. Generate a new JWT signing key for the gateway instance, delete the old one (making sure issuer is identical to appsettings.json file).
+2. Delete all records in the network.endpoint table for gateway and all other federated instances.
+3. Restart the gateway container (ensure that it can read newly created signing key).
+4. Reload and exchange signing keys again by re-establishing trusts between instances (all instances must permit queries from the gateway also).
+5. Restart ALL containers.
+6. Clear browser cache. Attempt a federated query.


### PR DESCRIPTION
This PR adds tips on re-establishing federated instances in case queries fail, even when the instances are visible as successfully added as networked Leaf instances via Admin > Network & Identity. 

These were originally shared by @ndobb, and resolved 401 and JWT invalid token errors that were seen when the gateway attempted to make API calls to `/api/network/identity` on networked instances.