### PR TITLE
Add docker compose override for development

### DIFF
--- a/dev/gateway/docker-compose.dev.yaml
+++ b/dev/gateway/docker-compose.dev.yaml
@@ -1,0 +1,5 @@
+version: "3"
+services:
+  node:
+    volumes:
+      - ../../src/leaf/src/ui-client/:/app

--- a/dev/gateway/docker-compose.dev.yaml
+++ b/dev/gateway/docker-compose.dev.yaml
@@ -2,4 +2,7 @@ version: "3"
 services:
   node:
     volumes:
-      - ../../src/leaf/src/ui-client/:/app
+      # TODO move node_modules outside src/ directory
+      # do not mount entire src/ directory, so node_modules still exists
+      - ../../src/leaf/src/ui-client/src:/app/src
+      - ../../src/leaf/src/ui-client/public:/app/public


### PR DESCRIPTION
Add docker compose override for (frontend) development

To enable, add `gateway/docker-compose.dev.yaml` to `COMPOSE_FILE` in ` .env`