### PR TITLE
Add migration scripts to export concepts and import them to another Leaf instance

### DIFF
--- a/dev/migration-scripts/concept-cloner.sh
+++ b/dev/migration-scripts/concept-cloner.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+if [ "$#" -eq 0 ]; then
+    echo "Error: No arguments provided. You must specify a single docker service for concept export."
+    exit 1
+fi
+
+cat generate_inserts.sh | docker exec -i $1 bash
+docker cp $1:/tmp/appConcept.sql . 
+docker cp $1:/tmp/appConceptSqlSet.sql . 
+docker cp $1:/tmp/appSpecialization.sql . 
+docker cp $1:/tmp/appSpecializationGroup.sql . 

--- a/dev/migration-scripts/concept-replace.sh
+++ b/dev/migration-scripts/concept-replace.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+if [ "$#" -eq 0 ]; then
+    echo "Error: No arguments provided. You must specify a single docker service for concept replacement."
+    exit 1
+fi
+
+# Change to the desired directory
+cd /srv/www/leaf/leaf-environments/dev || exit
+
+# Run the command and assign the output to a variable
+container_name=$(docker inspect --format '{{.Name}}' $(docker compose ps -q $1) | sed 's|^/||')
+
+echo "Copying SQL inserts to $container_name ..."
+echo " "
+
+docker cp appConcept.sql "$container_name:/tmp/appConcept.sql"
+docker cp appConceptSqlSet.sql "$container_name:/tmp/appConceptSqlSet.sql"
+docker cp appSpecialization.sql "$container_name:/tmp/appSpecialization.sql"
+docker cp appSpecializationGroup.sql "$container_name:/tmp/appSpecializationGroup.sql"
+
+echo "Copying completed."
+echo " "
+
+echo "Deleting old concepts ..."
+
+cat insert_concepts.sh | docker exec -i "$container_name" bash

--- a/dev/migration-scripts/concept-replace.sh
+++ b/dev/migration-scripts/concept-replace.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Throw an error if no argument is passed -- the correct syntax is
+#   concept-replace.sh <docker-service-name>
+
 if [ "$#" -eq 0 ]; then
     echo "Error: No arguments provided. You must specify a single docker service for concept replacement."
     exit 1
@@ -14,6 +17,8 @@ container_name=$(docker inspect --format '{{.Name}}' $(docker compose ps -q $1) 
 echo "Copying SQL inserts to $container_name ..."
 echo " "
 
+# Copy the insert statements into the Docker container
+
 docker cp appConcept.sql "$container_name:/tmp/appConcept.sql"
 docker cp appConceptSqlSet.sql "$container_name:/tmp/appConceptSqlSet.sql"
 docker cp appSpecialization.sql "$container_name:/tmp/appSpecialization.sql"
@@ -22,6 +27,8 @@ docker cp appSpecializationGroup.sql "$container_name:/tmp/appSpecializationGrou
 echo "Copying completed."
 echo " "
 
-echo "Deleting old concepts ..."
+echo "Deleting old concepts and inserting new ones ..."
+
+# Insert the new concepts and specializations
 
 cat insert_concepts.sh | docker exec -i "$container_name" bash

--- a/dev/migration-scripts/generate_inserts.R
+++ b/dev/migration-scripts/generate_inserts.R
@@ -1,0 +1,113 @@
+# Script to convert R data frame objects to SQL
+#
+# gently modified from version originally posted to
+# https://stackoverflow.com/a/73063553
+#
+# and extracted from the DBI package
+
+library(DBI)
+library(odbc)
+library(magrittr)
+
+# suggested usage:
+#
+#   sink(file = "patient.sql")
+#   get_table_sql("patient", as.data.frame(dataset_name))
+#   sink(file = NULL)
+
+do_sql_quote_id <- function(x) getMethod("dbQuoteIdentifier", 
+                                         c(conn = "DBIConnection",
+                                           x="character"))@.Data(x = x)
+
+do_sql_quote_string <- function(x) getMethod("dbQuoteString", 
+                                             c(conn = "DBIConnection", 
+                                               x = "character"))@.Data(x = x)
+
+do_sql_quote_literal <- function(x) {
+  if (is(x, "SQL")) 
+    return(x)
+  if (is.factor(x)) 
+    return(do_sql_quote_string(as.character(x)))
+  if (is.character(x)) 
+    return(do_sql_quote_string(x))
+  if (inherits(x, "POSIXt")) {
+    return(do_sql_quote_string(strftime(as.POSIXct(x), "%Y%m%d%H%M%S", 
+                                        tz = "UTC")))
+  }
+  if (inherits(x, "Date")) 
+    return(do_sql_quote_string(as.character(x)))
+  if (inherits(x, "difftime")) 
+    return(do_sql_quote_string(format_hms(x)))
+  if (is.list(x)) {
+    blob_data <- vapply(x, function(x) {
+      if (is.null(x)) {
+        "NULL"
+      }
+      else if (is.raw(x)) {
+        paste0("X'", paste(format(x), collapse = ""), 
+               "'")
+      }
+      else {
+        stop("Lists must contain raw vectors or NULL", 
+             call. = FALSE)
+      }
+    }, character(1))
+    return(SQL(blob_data, names = names(x)))
+  }
+  if (is.logical(x)) 
+    x <- as.numeric(x)
+  x <- as.character(x)
+  x[is.na(x)] <- "NULL"
+  SQL(x, names = names(x))
+}
+
+get_data_type <- function(obj) {
+  res <- character(NCOL(obj))
+  nms <- names(obj)
+  for (i in seq_along(obj)) {
+    # RK: the SO code seemed to have an outdated method reference
+    # res[[i]] <- odbc:::`odbcDataType.Microsoft SQL Server`(obj = obj[[i]])
+    #
+    # so I used the following statement to dump the supported types:
+    #
+    # showMethods(odbcDataType)
+    #
+    # this seems to have worked
+    res[[i]] <- odbc:::odbcDataType(con="MySQL", obj = obj[[i]])
+  }
+  names(res) <- nms
+  field_names <- do_sql_quote_id(names(res))
+  field_types <- unname(res)
+  paste0(field_names, " ", field_types)
+}
+
+df_to_sql_data <- function(value) {
+  is_POSIXlt <- vapply(value, function(x) is.object(x) && (is(x, 
+                                                              "POSIXlt")), logical(1))
+  value[is_POSIXlt] <- lapply(value[is_POSIXlt], as.POSIXct)
+  is_IDate <- vapply(value, function(x) is.object(x) && (is(x, 
+                                                            "IDate")), logical(1))
+  value[is_IDate] <- lapply(value[is_IDate], as.Date)
+  is_object <- vapply(value, function(x) is.object(x) && !(is(x, 
+                                                              "POSIXct") || is(x, "Date") || odbc:::is_blob(x) || 
+                                                             is(x, "difftime")), logical(1))
+  value[is_object] <- lapply(value[is_object], as.character)
+  value
+}
+
+get_table_sql <- function(name, my_data) {
+  table <- do_sql_quote_id(name)
+  fields <- get_data_type(my_data)
+  ct <- paste0("CREATE TABLE ", table, " (\n", 
+               "  ", paste(fields, collapse = ",\n  "), 
+               "\n)\n")
+  values <- df_to_sql_data(my_data)
+  fields <- do_sql_quote_id(names(values))
+  rows <- split(values, seq_len(nrow(values))) %>%
+    lapply(function(row) do.call(paste, 
+                                 c(sep = ", ", lapply(row, do_sql_quote_literal))))
+  it <- paste0("INSERT INTO ", table, " (", 
+               paste0(fields, collapse = ", "), ")\n", 
+               "VALUES \n", paste0("(", rows, ")", collapse = ", \n"))
+  SQL(paste0(ct, "\n", it))
+}

--- a/dev/migration-scripts/generate_inserts.sh
+++ b/dev/migration-scripts/generate_inserts.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
+
+# output insert statements for required concept-related tables
 /opt/mssql-tools/bin/sqlcmd -d LeafDB -U sa -P ${SA_PASSWORD} -Q "EXEC sp_generate_inserts 'Specialization', @owner = 'app'" -o /tmp/appSpecialization.sql -y 0
 /opt/mssql-tools/bin/sqlcmd -d LeafDB -U sa -P ${SA_PASSWORD} -Q "EXEC sp_generate_inserts 'Concept', @owner = 'app'" -o /tmp/appConcept.sql -y 0
 /opt/mssql-tools/bin/sqlcmd -d LeafDB -U sa -P ${SA_PASSWORD} -Q "EXEC sp_generate_inserts 'ConceptSqlSet', @owner = 'app'" -o /tmp/appConceptSqlSet.sql -y 0
 /opt/mssql-tools/bin/sqlcmd -d LeafDB -U sa -P ${SA_PASSWORD} -Q "EXEC sp_generate_inserts 'SpecializationGroup', @owner = 'app'" -o /tmp/appSpecializationGroup.sql -y 0
 
+# remove trailing spaces within quoted strings, as these were not present in the original table
 sed -Ei "s/('[^']*[^[:space:]])[[:space:]]*'/\1'/g" /tmp/appConcept.sql
 sed -Ei "s/('[^']*[^[:space:]])[[:space:]]*'/\1'/g" /tmp/appSpecialization.sql

--- a/dev/migration-scripts/generate_inserts.sh
+++ b/dev/migration-scripts/generate_inserts.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+/opt/mssql-tools/bin/sqlcmd -d LeafDB -U sa -P ${SA_PASSWORD} -Q "EXEC sp_generate_inserts 'Specialization', @owner = 'app'" -o /tmp/appSpecialization.sql -y 0
+/opt/mssql-tools/bin/sqlcmd -d LeafDB -U sa -P ${SA_PASSWORD} -Q "EXEC sp_generate_inserts 'Concept', @owner = 'app'" -o /tmp/appConcept.sql -y 0
+/opt/mssql-tools/bin/sqlcmd -d LeafDB -U sa -P ${SA_PASSWORD} -Q "EXEC sp_generate_inserts 'ConceptSqlSet', @owner = 'app'" -o /tmp/appConceptSqlSet.sql -y 0
+/opt/mssql-tools/bin/sqlcmd -d LeafDB -U sa -P ${SA_PASSWORD} -Q "EXEC sp_generate_inserts 'SpecializationGroup', @owner = 'app'" -o /tmp/appSpecializationGroup.sql -y 0
+
+sed -Ei "s/('[^']*[^[:space:]])[[:space:]]*'/\1'/g" /tmp/appConcept.sql
+sed -Ei "s/('[^']*[^[:space:]])[[:space:]]*'/\1'/g" /tmp/appSpecialization.sql

--- a/dev/migration-scripts/insert_concepts.sh
+++ b/dev/migration-scripts/insert_concepts.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
+
+# delete relationship entries to avoid foreign key errors which would otherwise occur on insert
 /opt/mssql-tools/bin/sqlcmd -d LeafDB -U sa -P ${SA_PASSWORD} -Q "SET QUOTED_IDENTIFIER ON; DELETE FROM [rela].[QueryConceptDependency]" && echo "- rela.QueryConceptDependency rows deleted."
 
 /opt/mssql-tools/bin/sqlcmd -d LeafDB -U sa -P ${SA_PASSWORD} -Q "SET QUOTED_IDENTIFIER ON; DELETE FROM [rela].[ConceptSpecializationGroup]" && echo "- rela.ConceptSpecializationGroup rows deleted."
 
+# delete concept and specialization entries from relevant tables before refreshing via insert
 /opt/mssql-tools/bin/sqlcmd -d LeafDB -U sa -P ${SA_PASSWORD} -Q "SET QUOTED_IDENTIFIER ON; DELETE FROM [app].[Specialization]" && echo "- app.Specialization rows deleted."
 
 /opt/mssql-tools/bin/sqlcmd -d LeafDB -U sa -P ${SA_PASSWORD} -Q "SET QUOTED_IDENTIFIER ON; DELETE FROM [app].[Concept]" && echo "- app.Concept rows deleted."
@@ -11,10 +14,12 @@
 
 /opt/mssql-tools/bin/sqlcmd -d LeafDB -U sa -P ${SA_PASSWORD} -Q "SET QUOTED_IDENTIFIER ON; DELETE FROM [app].[ConceptSqlSet]" && echo "- app.ConceptSqlSet rows deleted."
 
+# insert the new concept and specialization data into the tables on the receiving instance
 /opt/mssql-tools/bin/sqlcmd -d LeafDB -U sa -P ${SA_PASSWORD} -i /tmp/appConceptSqlSet.sql
 
 /opt/mssql-tools/bin/sqlcmd -d LeafDB -U sa -P ${SA_PASSWORD} -i /tmp/appSpecializationGroup.sql
 
 /opt/mssql-tools/bin/sqlcmd -d LeafDB -U sa -P ${SA_PASSWORD} -i /tmp/appSpecialization.sql
 
+# here the -I switch is used to avoid errors regarding quoted identifiers
 /opt/mssql-tools/bin/sqlcmd -d LeafDB -U sa -P ${SA_PASSWORD} -I -i /tmp/appConcept.sql

--- a/dev/migration-scripts/insert_concepts.sh
+++ b/dev/migration-scripts/insert_concepts.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+/opt/mssql-tools/bin/sqlcmd -d LeafDB -U sa -P ${SA_PASSWORD} -Q "SET QUOTED_IDENTIFIER ON; DELETE FROM [rela].[QueryConceptDependency]" && echo "- rela.QueryConceptDependency rows deleted."
+
+/opt/mssql-tools/bin/sqlcmd -d LeafDB -U sa -P ${SA_PASSWORD} -Q "SET QUOTED_IDENTIFIER ON; DELETE FROM [rela].[ConceptSpecializationGroup]" && echo "- rela.ConceptSpecializationGroup rows deleted."
+
+/opt/mssql-tools/bin/sqlcmd -d LeafDB -U sa -P ${SA_PASSWORD} -Q "SET QUOTED_IDENTIFIER ON; DELETE FROM [app].[Specialization]" && echo "- app.Specialization rows deleted."
+
+/opt/mssql-tools/bin/sqlcmd -d LeafDB -U sa -P ${SA_PASSWORD} -Q "SET QUOTED_IDENTIFIER ON; DELETE FROM [app].[Concept]" && echo "- app.Concept rows deleted."
+
+/opt/mssql-tools/bin/sqlcmd -d LeafDB -U sa -P ${SA_PASSWORD} -Q "SET QUOTED_IDENTIFIER ON; DELETE FROM [app].[SpecializationGroup]" && echo "- app.SpecializationGroup rows deleted."
+
+/opt/mssql-tools/bin/sqlcmd -d LeafDB -U sa -P ${SA_PASSWORD} -Q "SET QUOTED_IDENTIFIER ON; DELETE FROM [app].[ConceptSqlSet]" && echo "- app.ConceptSqlSet rows deleted."
+
+/opt/mssql-tools/bin/sqlcmd -d LeafDB -U sa -P ${SA_PASSWORD} -i /tmp/appConceptSqlSet.sql
+
+/opt/mssql-tools/bin/sqlcmd -d LeafDB -U sa -P ${SA_PASSWORD} -i /tmp/appSpecializationGroup.sql
+
+/opt/mssql-tools/bin/sqlcmd -d LeafDB -U sa -P ${SA_PASSWORD} -i /tmp/appSpecialization.sql
+
+/opt/mssql-tools/bin/sqlcmd -d LeafDB -U sa -P ${SA_PASSWORD} -I -i /tmp/appConcept.sql

--- a/dev/migration-scripts/sp_generate_inserts.sql
+++ b/dev/migration-scripts/sp_generate_inserts.sql
@@ -1,0 +1,477 @@
+SET NOCOUNT ON
+GO
+
+PRINT 'Using Master database'
+USE master
+GO
+
+PRINT 'Checking for the existence of this procedure'
+IF (SELECT OBJECT_ID('sp_generate_inserts','P')) IS NOT NULL --means, the procedure already exists
+	BEGIN
+		PRINT 'Procedure already exists. So, dropping it'
+		DROP PROC sp_generate_inserts
+	END
+GO
+
+CREATE PROC sp_generate_inserts
+(
+	@table_name varchar(776),  		-- The table/view for which the INSERT statements will be generated using the existing data
+	@target_table varchar(776) = NULL, 	-- Use this parameter to specify a different table name into which the data will be inserted
+	@include_column_list bit = 1,		-- Use this parameter to include/ommit column list in the generated INSERT statement
+	@from varchar(800) = NULL, 		-- Use this parameter to filter the rows based on a filter condition (using WHERE)
+	@include_timestamp bit = 0, 		-- Specify 1 for this parameter, if you want to include the TIMESTAMP/ROWVERSION column's data in the INSERT statement
+	@debug_mode bit = 0,			-- If @debug_mode is set to 1, the SQL statements constructed by this procedure will be printed for later examination
+	@owner varchar(64) = NULL,		-- Use this parameter if you are not the owner of the table
+	@ommit_images bit = 0,			-- Use this parameter to generate INSERT statements by omitting the 'image' columns
+	@ommit_identity bit = 0,		-- Use this parameter to ommit the identity columns
+	@top int = NULL,			-- Use this parameter to generate INSERT statements only for the TOP n rows
+	@cols_to_include varchar(8000) = NULL,	-- List of columns to be included in the INSERT statement
+	@cols_to_exclude varchar(8000) = NULL,	-- List of columns to be excluded from the INSERT statement
+	@disable_constraints bit = 0,		-- When 1, disables foreign key constraints and enables them after the INSERT statements
+	@ommit_computed_cols bit = 0		-- When 1, computed columns will not be included in the INSERT statement
+	
+)
+AS
+BEGIN
+
+/***********************************************************************************************************
+Procedure:	sp_generate_inserts  (Build 22) 
+		(Copyright © 2002 Narayana Vyas Kondreddi. All rights reserved.)
+                                          
+Purpose:	To generate INSERT statements from existing data. 
+		These INSERTS can be executed to regenerate the data at some other location.
+		This procedure is also useful to create a database setup, where in you can 
+		script your data along with your table definitions.
+
+Written by:	Narayana Vyas Kondreddi
+	        http://vyaskn.tripod.com
+
+Acknowledgements:
+		Divya Kalra	-- For beta testing
+		Mark Charsley	-- For reporting a problem with scripting uniqueidentifier columns with NULL values
+		Artur Zeygman	-- For helping me simplify a bit of code for handling non-dbo owned tables
+		Joris Laperre   -- For reporting a regression bug in handling text/ntext columns
+
+Tested on: 	SQL Server 7.0 and SQL Server 2000
+
+Date created:	January 17th 2001 21:52 GMT
+
+Date modified:	May 1st 2002 19:50 GMT
+
+Email: 		vyaskn@hotmail.com
+
+NOTE:		This procedure may not work with tables with too many columns.
+		Results can be unpredictable with huge text columns or SQL Server 2000's sql_variant data types
+		Whenever possible, Use @include_column_list parameter to ommit column list in the INSERT statement, for better results
+		IMPORTANT: This procedure is not tested with internation data (Extended characters or Unicode). If needed
+		you might want to convert the datatypes of character variables in this procedure to their respective unicode counterparts
+		like nchar and nvarchar
+		
+
+Example 1:	To generate INSERT statements for table 'titles':
+		
+		EXEC sp_generate_inserts 'titles'
+
+Example 2: 	To ommit the column list in the INSERT statement: (Column list is included by default)
+		IMPORTANT: If you have too many columns, you are advised to ommit column list, as shown below,
+		to avoid erroneous results
+		generate_inserts.txt.1
+		EXEC sp_generate_inserts 'titles', @include_column_list = 0
+
+Example 3:	To generate INSERT statements for 'titlesCopy' table from 'titles' table:
+
+		EXEC sp_generate_inserts 'titles', 'titlesCopy'
+
+Example 4:	To generate INSERT statements for 'titles' table for only those titles 
+		which contain the word 'Computer' in them:
+		NOTE: Do not complicate the FROM or WHERE clause here. It's assumed that you are good with T-SQL if you are using this parameter
+
+		EXEC sp_generate_inserts 'titles', @from = "from titles where title like '%Computer%'"
+
+Example 5: 	To specify that you want to include TIMESTAMP column's data as well in the INSERT statement:
+		(By default TIMESTAMP column's data is not scripted)
+
+		EXEC sp_generate_inserts 'titles', @include_timestamp = 1
+
+Example 6:	To print the debug information:
+  
+		EXEC sp_generate_inserts 'titles', @debug_mode = 1
+
+Example 7: 	If you are not the owner of the table, use @owner parameter to specify the owner name
+		To use this option, you must have SELECT permissions on that table
+
+		EXEC sp_generate_inserts Nickstable, @owner = 'Nick'
+
+Example 8: 	To generate INSERT statements for the rest of the columns excluding images
+		When using this otion, DO NOT set @include_column_list parameter to 0.
+
+		EXEC sp_generate_inserts imgtable, @ommit_images = 1
+
+Example 9: 	To generate INSERT statements excluding (ommiting) IDENTITY columns:
+		(By default IDENTITY columns are included in the INSERT statement)
+
+		EXEC sp_generate_inserts mytable, @ommit_identity = 1
+
+Example 10: 	To generate INSERT statements for the TOP 10 rows in the table:
+		
+		EXEC sp_generate_inserts mytable, @top = 10
+
+Example 11: 	To generate INSERT statements with only those columns you want:
+		
+		EXEC sp_generate_inserts titles, @cols_to_include = "'title','title_id','au_id'"
+
+Example 12: 	To generate INSERT statements by omitting certain columns:
+		
+		EXEC sp_generate_inserts titles, @cols_to_exclude = "'title','title_id','au_id'"
+
+Example 13:	To avoid checking the foreign key constraints while loading data with INSERT statements:
+		
+		EXEC sp_generate_inserts titles, @disable_constraints = 1
+
+Example 14: 	To exclude computed columns from the INSERT statement:
+		EXEC sp_generate_inserts MyTable, @ommit_computed_cols = 1
+***********************************************************************************************************/
+
+SET NOCOUNT ON
+
+--Making sure user only uses either @cols_to_include or @cols_to_exclude
+IF ((@cols_to_include IS NOT NULL) AND (@cols_to_exclude IS NOT NULL))
+	BEGIN
+		RAISERROR('Use either @cols_to_include or @cols_to_exclude. Do not use both the parameters at once',16,1)
+		RETURN -1 --Failure. Reason: Both @cols_to_include and @cols_to_exclude parameters are specified
+	END
+
+--Making sure the @cols_to_include and @cols_to_exclude parameters are receiving values in proper format
+IF ((@cols_to_include IS NOT NULL) AND (PATINDEX('''%''',@cols_to_include) = 0))
+	BEGIN
+		RAISERROR('Invalid use of @cols_to_include property',16,1)
+		PRINT 'Specify column names surrounded by single quotes and separated by commas'
+		PRINT 'Eg: EXEC sp_generate_inserts titles, @cols_to_include = "''title_id'',''title''"'
+		RETURN -1 --Failure. Reason: Invalid use of @cols_to_include property
+	END
+
+IF ((@cols_to_exclude IS NOT NULL) AND (PATINDEX('''%''',@cols_to_exclude) = 0))
+	BEGIN
+		RAISERROR('Invalid use of @cols_to_exclude property',16,1)
+		PRINT 'Specify column names surrounded by single quotes and separated by commas'
+		PRINT 'Eg: EXEC sp_generate_inserts titles, @cols_to_exclude = "''title_id'',''title''"'
+		RETURN -1 --Failure. Reason: Invalid use of @cols_to_exclude property
+	END
+
+
+--Checking to see if the database name is specified along wih the table name
+--Your database context should be local to the table for which you want to generate INSERT statements
+--specifying the database name is not allowed
+IF (PARSENAME(@table_name,3)) IS NOT NULL
+	BEGIN
+		RAISERROR('Do not specify the database name. Be in the required database and just specify the table name.',16,1)
+		RETURN -1 --Failure. Reason: Database name is specified along with the table name, which is not allowed
+	END
+
+--Checking for the existence of 'user table' or 'view'
+--This procedure is not written to work on system tables
+--To script the data in system tables, just create a view on the system tables and script the view instead
+
+IF @owner IS NULL
+	BEGIN
+		IF ((OBJECT_ID(@table_name,'U') IS NULL) AND (OBJECT_ID(@table_name,'V') IS NULL)) 
+			BEGIN
+				RAISERROR('User table or view not found.',16,1)
+				PRINT 'You may see this error, if you are not the owner of this table or view. In that case use @owner parameter to specify the owner name.'
+				PRINT 'Make sure you have SELECT permission on that table or view.'
+				RETURN -1 --Failure. Reason: There is no user table or view with this name
+			END
+	END
+ELSE
+	BEGIN
+		IF NOT EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = @table_name AND (TABLE_TYPE = 'BASE TABLE' OR TABLE_TYPE = 'VIEW') AND TABLE_SCHEMA = @owner)
+			BEGIN
+				RAISERROR('User table or view not found.',16,1)
+				PRINT 'You may see this error, if you are not the owner of this table. In that case use @owner parameter to specify the owner name.'
+				PRINT 'Make sure you have SELECT permission on that table or view.'
+				RETURN -1 --Failure. Reason: There is no user table or view with this name		
+			END
+	END
+
+--Variable declarations
+DECLARE		@Column_ID int, 		
+		@Column_List varchar(8000), 
+		@Column_Name varchar(128), 
+		@Start_Insert varchar(786), 
+		@Data_Type varchar(128), 
+		@Actual_Values varchar(8000),	--This is the string that will be finally executed to generate INSERT statements
+		@IDN varchar(128)		--Will contain the IDENTITY column's name in the table
+
+--Variable Initialization
+SET @IDN = ''
+SET @Column_ID = 0
+SET @Column_Name = ''
+SET @Column_List = ''
+SET @Actual_Values = ''
+
+IF @owner IS NULL 
+	BEGIN
+		SET @Start_Insert = 'INSERT INTO ' + '[' + RTRIM(COALESCE(@target_table,@table_name)) + ']' 
+	END
+ELSE
+	BEGIN
+		SET @Start_Insert = 'INSERT ' + '[' + LTRIM(RTRIM(@owner)) + '].' + '[' + RTRIM(COALESCE(@target_table,@table_name)) + ']' 		
+	END
+
+
+--To get the first column's ID
+
+SELECT	@Column_ID = MIN(ORDINAL_POSITION) 	
+FROM	INFORMATION_SCHEMA.COLUMNS (NOLOCK) 
+WHERE 	TABLE_NAME = @table_name AND
+(@owner IS NULL OR TABLE_SCHEMA = @owner)
+
+
+
+--Loop through all the columns of the table, to get the column names and their data types
+WHILE @Column_ID IS NOT NULL
+	BEGIN
+		SELECT 	@Column_Name = QUOTENAME(COLUMN_NAME), 
+		@Data_Type = DATA_TYPE 
+		FROM 	INFORMATION_SCHEMA.COLUMNS (NOLOCK) 
+		WHERE 	ORDINAL_POSITION = @Column_ID AND 
+		TABLE_NAME = @table_name AND
+		(@owner IS NULL OR TABLE_SCHEMA = @owner)
+
+
+
+		IF @cols_to_include IS NOT NULL --Selecting only user specified columns
+		BEGIN
+			IF CHARINDEX( '''' + SUBSTRING(@Column_Name,2,LEN(@Column_Name)-2) + '''',@cols_to_include) = 0 
+			BEGIN
+				GOTO SKIP_LOOP
+			END
+		END
+
+		IF @cols_to_exclude IS NOT NULL --Selecting only user specified columns
+		BEGIN
+			IF CHARINDEX( '''' + SUBSTRING(@Column_Name,2,LEN(@Column_Name)-2) + '''',@cols_to_exclude) <> 0 
+			BEGIN
+				GOTO SKIP_LOOP
+			END
+		END
+
+		--Making sure to output SET IDENTITY_INSERT ON/OFF in case the table has an IDENTITY column
+		IF (SELECT COLUMNPROPERTY( OBJECT_ID(QUOTENAME(COALESCE(@owner,USER_NAME())) + '.' + @table_name),SUBSTRING(@Column_Name,2,LEN(@Column_Name) - 2),'IsIdentity')) = 1 
+		BEGIN
+			IF @ommit_identity = 0 --Determing whether to include or exclude the IDENTITY column
+				SET @IDN = @Column_Name
+			ELSE
+				GOTO SKIP_LOOP			
+		END
+		
+		--Making sure whether to output computed columns or not
+		IF @ommit_computed_cols = 1
+		BEGIN
+			IF (SELECT COLUMNPROPERTY( OBJECT_ID(QUOTENAME(COALESCE(@owner,USER_NAME())) + '.' + @table_name),SUBSTRING(@Column_Name,2,LEN(@Column_Name) - 2),'IsComputed')) = 1 
+			BEGIN
+				GOTO SKIP_LOOP					
+			END
+		END
+		
+		--Tables with columns of IMAGE data type are not supported for obvious reasons
+		IF(@Data_Type in ('image'))
+			BEGIN
+				IF (@ommit_images = 0)
+					BEGIN
+						RAISERROR('Tables with image columns are not supported.',16,1)
+						PRINT 'Use @ommit_images = 1 parameter to generate INSERTs for the rest of the columns.'
+						PRINT 'DO NOT ommit Column List in the INSERT statements. If you ommit column list using @include_column_list=0, the generated INSERTs will fail.'
+						RETURN -1 --Failure. Reason: There is a column with image data type
+					END
+				ELSE
+					BEGIN
+					GOTO SKIP_LOOP
+					END
+			END
+
+		--Determining the data type of the column and depending on the data type, the VALUES part of
+		--the INSERT statement is generated. Care is taken to handle columns with NULL values. Also
+		--making sure, not to lose any data from flot, real, money, smallmomey, datetime columns
+		SET @Actual_Values = @Actual_Values  +
+		CASE 
+			WHEN @Data_Type IN ('char','varchar','nchar','nvarchar') 
+				THEN 
+					'COALESCE('''''''' + REPLACE(RTRIM(' + @Column_Name + '),'''''''','''''''''''')+'''''''',''NULL'')'
+			WHEN @Data_Type IN ('datetime','smalldatetime') 
+				THEN 
+					'COALESCE('''''''' + RTRIM(CONVERT(char,' + @Column_Name + ',109))+'''''''',''NULL'')'
+			WHEN @Data_Type IN ('uniqueidentifier') 
+				THEN  
+					'COALESCE('''''''' + REPLACE(CONVERT(char(255),RTRIM(' + @Column_Name + ')),'''''''','''''''''''')+'''''''',''NULL'')'
+			WHEN @Data_Type IN ('text','ntext') 
+				THEN  
+					'COALESCE('''''''' + REPLACE(CONVERT(char(8000),' + @Column_Name + '),'''''''','''''''''''')+'''''''',''NULL'')'					
+			WHEN @Data_Type IN ('binary','varbinary') 
+				THEN  
+					'COALESCE(RTRIM(CONVERT(char,' + 'CONVERT(int,' + @Column_Name + '))),''NULL'')'  
+			WHEN @Data_Type IN ('timestamp','rowversion') 
+				THEN  
+					CASE 
+						WHEN @include_timestamp = 0 
+							THEN 
+								'''DEFAULT''' 
+							ELSE 
+								'COALESCE(RTRIM(CONVERT(char,' + 'CONVERT(int,' + @Column_Name + '))),''NULL'')'  
+					END
+			WHEN @Data_Type IN ('float','real','money','smallmoney')
+				THEN
+					'COALESCE(LTRIM(RTRIM(' + 'CONVERT(char, ' +  @Column_Name  + ',2)' + ')),''NULL'')' 
+			ELSE 
+				'COALESCE(LTRIM(RTRIM(' + 'CONVERT(char, ' +  @Column_Name  + ')' + ')),''NULL'')' 
+		END   + '+' +  ''',''' + ' + '
+		
+		--Generating the column list for the INSERT statement
+		SET @Column_List = @Column_List +  @Column_Name + ','	
+
+		SKIP_LOOP: --The label used in GOTO
+
+		SELECT 	@Column_ID = MIN(ORDINAL_POSITION) 
+		FROM 	INFORMATION_SCHEMA.COLUMNS (NOLOCK) 
+		WHERE 	TABLE_NAME = @table_name AND 
+		ORDINAL_POSITION > @Column_ID AND
+		(@owner IS NULL OR TABLE_SCHEMA = @owner)
+
+
+	--Loop ends here!
+	END
+
+--To get rid of the extra characters that got concatenated during the last run through the loop
+SET @Column_List = LEFT(@Column_List,len(@Column_List) - 1)
+SET @Actual_Values = LEFT(@Actual_Values,len(@Actual_Values) - 6)
+
+IF LTRIM(@Column_List) = '' 
+	BEGIN
+		RAISERROR('No columns to select. There should at least be one column to generate the output',16,1)
+		RETURN -1 --Failure. Reason: Looks like all the columns are ommitted using the @cols_to_exclude parameter
+	END
+
+--Forming the final string that will be executed, to output the INSERT statements
+IF (@include_column_list <> 0)
+	BEGIN
+		SET @Actual_Values = 
+			'SELECT ' +  
+			CASE WHEN @top IS NULL OR @top < 0 THEN '' ELSE ' TOP ' + LTRIM(STR(@top)) + ' ' END + 
+			'''' + RTRIM(@Start_Insert) + 
+			' ''+' + '''(' + RTRIM(@Column_List) +  '''+' + ''')''' + 
+			' +''VALUES(''+ ' +  @Actual_Values  + '+'')''' + ' ' + 
+			COALESCE(@from,' FROM ' + CASE WHEN @owner IS NULL THEN '' ELSE '[' + LTRIM(RTRIM(@owner)) + '].' END + '[' + rtrim(@table_name) + ']' + '(NOLOCK)')
+	END
+ELSE IF (@include_column_list = 0)
+	BEGIN
+		SET @Actual_Values = 
+			'SELECT ' + 
+			CASE WHEN @top IS NULL OR @top < 0 THEN '' ELSE ' TOP ' + LTRIM(STR(@top)) + ' ' END + 
+			'''' + RTRIM(@Start_Insert) + 
+			' '' +''VALUES(''+ ' +  @Actual_Values + '+'')''' + ' ' + 
+			COALESCE(@from,' FROM ' + CASE WHEN @owner IS NULL THEN '' ELSE '[' + LTRIM(RTRIM(@owner)) + '].' END + '[' + rtrim(@table_name) + ']' + '(NOLOCK)')
+	END	
+
+--Determining whether to ouput any debug information
+IF @debug_mode =1
+	BEGIN
+		PRINT '/*****START OF DEBUG INFORMATION*****'
+		PRINT 'Beginning of the INSERT statement:'
+		PRINT @Start_Insert
+		PRINT ''
+		PRINT 'The column list:'
+		PRINT @Column_List
+		PRINT ''
+		PRINT 'The SELECT statement executed to generate the INSERTs'
+		PRINT @Actual_Values
+		PRINT ''
+		PRINT '*****END OF DEBUG INFORMATION*****/'
+		PRINT ''
+	END
+		
+PRINT '--INSERTs generated by ''sp_generate_inserts'' stored procedure written by Vyas'
+PRINT '--Build number: 22'
+PRINT '--Problems/Suggestions? Contact Vyas @ vyaskn@hotmail.com'
+PRINT '--http://vyaskn.tripod.com'
+PRINT ''
+PRINT 'SET NOCOUNT ON'
+PRINT ''
+
+
+--Determining whether to print IDENTITY_INSERT or not
+IF (@IDN <> '')
+	BEGIN
+		PRINT 'SET IDENTITY_INSERT ' + QUOTENAME(COALESCE(@owner,USER_NAME())) + '.' + QUOTENAME(@table_name) + ' ON'
+		PRINT 'GO'
+		PRINT ''
+	END
+
+
+IF @disable_constraints = 1 AND (OBJECT_ID(QUOTENAME(COALESCE(@owner,USER_NAME())) + '.' + @table_name, 'U') IS NOT NULL)
+	BEGIN
+		IF @owner IS NULL
+			BEGIN
+				SELECT 	'ALTER TABLE ' + QUOTENAME(COALESCE(@target_table, @table_name)) + ' NOCHECK CONSTRAINT ALL' AS '--Code to disable constraints temporarily'
+			END
+		ELSE
+			BEGIN
+				SELECT 	'ALTER TABLE ' + QUOTENAME(@owner) + '.' + QUOTENAME(COALESCE(@target_table, @table_name)) + ' NOCHECK CONSTRAINT ALL' AS '--Code to disable constraints temporarily'
+			END
+
+		PRINT 'GO'
+	END
+
+PRINT ''
+PRINT 'PRINT ''Inserting values into ' + '[' + RTRIM(COALESCE(@target_table,@table_name)) + ']' + ''''
+
+
+--All the hard work pays off here!!! You'll get your INSERT statements, when the next line executes!
+EXEC (@Actual_Values)
+
+PRINT 'PRINT ''Done'''
+PRINT ''
+
+
+IF @disable_constraints = 1 AND (OBJECT_ID(QUOTENAME(COALESCE(@owner,USER_NAME())) + '.' + @table_name, 'U') IS NOT NULL)
+	BEGIN
+		IF @owner IS NULL
+			BEGIN
+				SELECT 	'ALTER TABLE ' + QUOTENAME(COALESCE(@target_table, @table_name)) + ' CHECK CONSTRAINT ALL'  AS '--Code to enable the previously disabled constraints'
+			END
+		ELSE
+			BEGIN
+				SELECT 	'ALTER TABLE ' + QUOTENAME(@owner) + '.' + QUOTENAME(COALESCE(@target_table, @table_name)) + ' CHECK CONSTRAINT ALL' AS '--Code to enable the previously disabled constraints'
+			END
+
+		PRINT 'GO'
+	END
+
+PRINT ''
+IF (@IDN <> '')
+	BEGIN
+		PRINT 'SET IDENTITY_INSERT ' + QUOTENAME(COALESCE(@owner,USER_NAME())) + '.' + QUOTENAME(@table_name) + ' OFF'
+		PRINT 'GO'
+	END
+
+PRINT 'SET NOCOUNT OFF'
+
+
+SET NOCOUNT OFF
+RETURN 0 --Success. We are done!
+END
+
+GO
+
+PRINT 'Created the procedure'
+GO
+
+EXEC sp_MS_marksystemobject sp_generate_inserts
+GO
+
+PRINT 'Granting EXECUTE permission on sp_generate_inserts to all users'
+GRANT EXEC ON sp_generate_inserts TO public
+
+SET NOCOUNT OFF
+GO
+
+PRINT 'Done'


### PR DESCRIPTION
This pull request aims to contribute the following assets to streamline concept migration from one Leaf instance to another:

- *sp_generate_inserts.sql* -- This stored procedure was obtained from [here](https://vyaskn.tripod.com/code/generate_inserts.txt) with corrections applied as suggested [here](https://stackoverflow.com/a/982587). The procedure generates an SQL insert statement from an existing SQL table so that the data contained within it can be loaded into another database.
- *concept-cloner.sh* -- This shell script calls `generate_inserts.sh`, which exports the `app.Specialization`, `app.Concept`, `app.ConceptSqlSet`, and `app.SpecializationGroup` tables using `sp_generate_inserts`, then copies the resulting INSERT statements into the Docker container specified by the argument provided to `concept-cloner.sh`. It also fixes up the output so that any single quotes are replaced with backticks, and trailing whitespace is removed when present inside of quoted strings.
- *concept-replace.sh* -- This script copies the INSERT statements generated by `concept-cloner.sh` into the Docker container, deletes old concepts and relationship information, then pushes the new concepts using the `insert_concepts.sh` shell script.
- *insert_concepts.sh* -- this is a helper script that repeatedly calls `sqlcmd` to remove and replace the required concept and specialization data.
- *generate_inserts.sh* -- this is a helper script that repeatedly calls `sqlcmd` to run `sp_generate_inserts` to export the required tables, and uses `sed` to fix up the output to remove trailing whitespace.

The usage is simple. The scripts use the Docker service name and extract the container name from `docker compose ps -a`, since it may be easier to recall the service name versus the container name:
```
./concept-cloner.sh leaf-env-prod-gateway-mssql-1
./concept-replace.sh jhhcc-mssql
```

In addition, the R script used to produce SQL tables from `data.frame` objects is also contributed here as `generate_inserts.R`, based on code posted [here](https://stackoverflow.com/a/73063553).