### PR TITLE
Disable connection pooling

### DIFF
--- a/dev/alive/docker-compose.yaml
+++ b/dev/alive/docker-compose.yaml
@@ -17,7 +17,7 @@ services:
     environment:
       LEAF_JWT_KEY_PW: ${ALIVE_JWT_KEY_PW}
       LEAF_APP_DB: Server=alive-mssql,1433;Database=LeafDB;uid=sa;Password=${MSSQL_SA_PASSWORD}
-      LEAF_CLIN_DB: Server=clin-db,3306;Database=alive;uid=db-user;Password=${MYSQL_PASSWORD}
+      LEAF_CLIN_DB: Server=clin-db,3306;Database=alive;uid=db-user;Password=${MYSQL_PASSWORD};Pooling=false
     labels:
       - traefik.http.routers.alive-coreapi-${COMPOSE_PROJECT_NAME}.rule=Host(`alive.${LEAF_DOMAIN}`) && PathPrefix(`/api`)
       - traefik.http.routers.alive-coreapi-${COMPOSE_PROJECT_NAME}.entrypoints=websecure

--- a/dev/gateway/docker-compose.yaml
+++ b/dev/gateway/docker-compose.yaml
@@ -17,7 +17,7 @@ services:
     environment:
       LEAF_JWT_KEY_PW: ${GATEWAY_JWT_KEY_PW}
       LEAF_APP_DB: Server=gateway-mssql,1433;Database=LeafDB;uid=sa;Password=${MSSQL_SA_PASSWORD}
-      LEAF_CLIN_DB: Server=clin-db,3306;Database=gateway;uid=db-user;Password=${MYSQL_PASSWORD}
+      LEAF_CLIN_DB: Server=clin-db,3306;Database=gateway;uid=db-user;Password=${MYSQL_PASSWORD};Pooling=false
     labels:
       - traefik.http.routers.gateway-coreapi-${COMPOSE_PROJECT_NAME}.rule=Host(`${LEAF_DOMAIN}`) && PathPrefix(`/api`)
       - traefik.http.routers.gateway-coreapi-${COMPOSE_PROJECT_NAME}.entrypoints=websecure

--- a/dev/hymtruth/docker-compose.yaml
+++ b/dev/hymtruth/docker-compose.yaml
@@ -17,7 +17,7 @@ services:
     environment:
       LEAF_JWT_KEY_PW: ${HYMTRUTH_JWT_KEY_PW}
       LEAF_APP_DB: Server=hymtruth-mssql,1433;Database=LeafDB;uid=sa;Password=${MSSQL_SA_PASSWORD}
-      LEAF_CLIN_DB: Server=clin-db,3306;Database=hymtruth;uid=db-user;Password=${MYSQL_PASSWORD}
+      LEAF_CLIN_DB: Server=clin-db,3306;Database=hymtruth;uid=db-user;Password=${MYSQL_PASSWORD};Pooling=false
     labels:
       - traefik.http.routers.hymtruth-coreapi-${COMPOSE_PROJECT_NAME}.rule=Host(`hymtruth.${LEAF_DOMAIN}`) && PathPrefix(`/api`)
       - traefik.http.routers.hymtruth-coreapi-${COMPOSE_PROJECT_NAME}.entrypoints=websecure

--- a/dev/mash/docker-compose.yaml
+++ b/dev/mash/docker-compose.yaml
@@ -17,7 +17,7 @@ services:
     environment:
       LEAF_JWT_KEY_PW: ${MASH_JWT_KEY_PW}
       LEAF_APP_DB: Server=mash-mssql,1433;Database=LeafDB;uid=sa;Password=${MSSQL_SA_PASSWORD}
-      LEAF_CLIN_DB: Server=clin-db,3306;Database=mash;uid=db-user;Password=${MYSQL_PASSWORD}
+      LEAF_CLIN_DB: Server=clin-db,3306;Database=mash;uid=db-user;Password=${MYSQL_PASSWORD};Pooling=false
     labels:
       - traefik.http.routers.mash-coreapi-${COMPOSE_PROJECT_NAME}.rule=Host(`mash.${LEAF_DOMAIN}`) && PathPrefix(`/api`)
       - traefik.http.routers.mash-coreapi-${COMPOSE_PROJECT_NAME}.entrypoints=websecure

--- a/dev/mstudy/docker-compose.yaml
+++ b/dev/mstudy/docker-compose.yaml
@@ -17,7 +17,7 @@ services:
     environment:
       LEAF_JWT_KEY_PW: ${MSTUDY_JWT_KEY_PW}
       LEAF_APP_DB: Server=mstudy-mssql,1433;Database=LeafDB;uid=sa;Password=${MSSQL_SA_PASSWORD}
-      LEAF_CLIN_DB: Server=clin-db,3306;Database=mstudy;uid=db-user;Password=${MYSQL_PASSWORD}
+      LEAF_CLIN_DB: Server=clin-db,3306;Database=mstudy;uid=db-user;Password=${MYSQL_PASSWORD};Pooling=false
     labels:
       - traefik.http.routers.mstudy-coreapi-${COMPOSE_PROJECT_NAME}.rule=Host(`mstudy.${LEAF_DOMAIN}`) && PathPrefix(`/api`)
       - traefik.http.routers.mstudy-coreapi-${COMPOSE_PROJECT_NAME}.entrypoints=websecure

--- a/dev/radar/docker-compose.yaml
+++ b/dev/radar/docker-compose.yaml
@@ -17,7 +17,7 @@ services:
     environment:
       LEAF_JWT_KEY_PW: ${RADAR_JWT_KEY_PW}
       LEAF_APP_DB: Server=radar-mssql,1433;Database=LeafDB;uid=sa;Password=${MSSQL_SA_PASSWORD}
-      LEAF_CLIN_DB: Server=clin-db,3306;Database=radar;uid=db-user;Password=${MYSQL_PASSWORD}
+      LEAF_CLIN_DB: Server=clin-db,3306;Database=radar;uid=db-user;Password=${MYSQL_PASSWORD};Pooling=false
     labels:
       - traefik.http.routers.radar-coreapi-${COMPOSE_PROJECT_NAME}.rule=Host(`radar.${LEAF_DOMAIN}`) && PathPrefix(`/api`)
       - traefik.http.routers.radar-coreapi-${COMPOSE_PROJECT_NAME}.entrypoints=websecure


### PR DESCRIPTION
Disable connection pooling for mariadb clinical DB to prevent reusing connections; see [MySql.Data config option](https://dev.mysql.com/doc/connector-net/en/connector-net-8-0-connection-options.html#connector-net-8-0-connection-options-classic-pooling)

I tried also adding `Pipelining=false` but that didn't work without uwcirg/leaf#12 being merged first