### PR TITLE
update attestation settings

### DIFF
--- a/dev/alive/appsettings.json
+++ b/dev/alive/appsettings.json
@@ -58,7 +58,12 @@
     }
   },
   "Attestation": {
-    "Enabled": true
+    "Enabled": true,
+    "Text": [
+      "HIV Success uses Leaf, a self-service tool which provides a user-friendly interface to execute queries and retrieve information about study data."
+    ],
+    "Type": "text",
+    "SkipModeSelection": true
   },
   "Compiler": {
     "Alias": "@",

--- a/dev/gateway/appsettings.json
+++ b/dev/gateway/appsettings.json
@@ -58,7 +58,12 @@
     }
   },
   "Attestation": {
-    "Enabled": true
+    "Enabled": true,
+    "Text": [
+      "HIV Success uses Leaf, a self-service tool which provides a user-friendly interface to execute queries and retrieve information about study data."
+    ],
+    "Type": "text",
+    "SkipModeSelection": true
   },
   "Compiler": {
     "Alias": "@",

--- a/dev/hymtruth/appsettings.json
+++ b/dev/hymtruth/appsettings.json
@@ -58,7 +58,12 @@
     }
   },
   "Attestation": {
-    "Enabled": true
+    "Enabled": true,
+    "Text": [
+      "HIV Success uses Leaf, a self-service tool which provides a user-friendly interface to execute queries and retrieve information about study data."
+    ],
+    "Type": "text",
+    "SkipModeSelection": true
   },
   "Compiler": {
     "Alias": "@",

--- a/dev/mash/appsettings.json
+++ b/dev/mash/appsettings.json
@@ -58,7 +58,12 @@
     }
   },
   "Attestation": {
-    "Enabled": true
+    "Enabled": true,
+    "Text": [
+      "HIV Success uses Leaf, a self-service tool which provides a user-friendly interface to execute queries and retrieve information about study data."
+    ],
+    "Type": "text",
+    "SkipModeSelection": true
   },
   "Compiler": {
     "Alias": "@",

--- a/dev/mstudy/appsettings.json
+++ b/dev/mstudy/appsettings.json
@@ -58,7 +58,12 @@
     }
   },
   "Attestation": {
-    "Enabled": true
+    "Enabled": true,
+    "Text": [
+      "HIV Success uses Leaf, a self-service tool which provides a user-friendly interface to execute queries and retrieve information about study data."
+    ],
+    "Type": "text",
+    "SkipModeSelection": true
   },
   "Compiler": {
     "Alias": "@",

--- a/dev/radar/appsettings.json
+++ b/dev/radar/appsettings.json
@@ -58,7 +58,12 @@
     }
   },
   "Attestation": {
-    "Enabled": true
+    "Enabled": true,
+    "Text": [
+      "HIV Success uses Leaf, a self-service tool which provides a user-friendly interface to execute queries and retrieve information about study data."
+    ],
+    "Type": "text",
+    "SkipModeSelection": true
   },
   "Compiler": {
     "Alias": "@",


### PR DESCRIPTION
Update settings for the initial **attestation** page to
- allow streamlining of initial button flow to skip selections, `SkipModeSelection=true`
- display custom text on the page (see screenshot)

![Screenshot 2025-02-04 at 11 34 31 AM](https://github.com/user-attachments/assets/1e5b9313-52e6-4463-889f-ab850e2d9ef6)

note the settings are pre-defined [here](https://github.com/uwcirg/leaf/blob/master/src/server/Model/Options/AttestationOptions.cs)
related UI changes are [here](https://github.com/uwcirg/leaf/pull/17)
